### PR TITLE
Remove api_secrets when logging errors

### DIFF
--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -151,6 +151,10 @@ class Worker(object):
             analyzer_input['config']['apikey'] = 'REMOVED'
         if 'api_key' in analyzer_input.get('config', {}):
             analyzer_input['config']['api_key'] = 'REMOVED'
+        if 'apisecret' in analyzer_input.get('config', {}):
+            analyzer_input['config']['apisecret'] = 'REMOVED'
+        if 'api_secret' in analyzer_input.get('config', {}):
+            analyzer_input['config']['api_secret'] = 'REMOVED'
 
         self.__write_output({'success': False,
                              'input': analyzer_input,

--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -155,6 +155,8 @@ class Worker(object):
             analyzer_input['config']['apisecret'] = 'REMOVED'
         if 'api_secret' in analyzer_input.get('config', {}):
             analyzer_input['config']['api_secret'] = 'REMOVED'
+        if 'secret' in analyzer_input.get('config', {}):
+            analyzer_input['config']['secret'] = 'REMOVED'
 
         self.__write_output({'success': False,
                              'input': analyzer_input,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='TheHive-Project',
     author_email='support@thehive-project.org',
     license='AGPL-V3',
-    url='https://github.com/TheHive-Project/Cortex-Analyzers/tree/master/contrib',
+    url='https://github.com/TheHive-Project/cortexutils/tree/master/',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tests/fixtures/test-error-response.json
+++ b/tests/fixtures/test-error-response.json
@@ -5,7 +5,7 @@
         "password": "secret",
         "key": "secret",
         "apikey": "secret",
-        "api_key": "secret"
+        "api_key": "secret",
         "apisecret": "secret",
         "api_secret": "secret"
     }

--- a/tests/fixtures/test-error-response.json
+++ b/tests/fixtures/test-error-response.json
@@ -6,5 +6,7 @@
         "key": "secret",
         "apikey": "secret",
         "api_key": "secret"
+        "apisecret": "secret",
+        "api_secret": "secret"
     }
 }

--- a/tests/fixtures/test-error-response.json
+++ b/tests/fixtures/test-error-response.json
@@ -7,6 +7,7 @@
         "apikey": "secret",
         "api_key": "secret",
         "apisecret": "secret",
-        "api_secret": "secret"
+        "api_secret": "secret",
+        "secret": "secret"
     }
 }

--- a/tests/test_suite_analyzer.py
+++ b/tests/test_suite_analyzer.py
@@ -107,6 +107,8 @@ class TestErrorResponse(unittest.TestCase):
         self.assertEqual(self.analyzer.get_param('config.key'), "secret")
         self.assertEqual(self.analyzer.get_param('config.apikey'), "secret")
         self.assertEqual(self.analyzer.get_param('config.api_key'), "secret")
+        self.assertEqual(self.analyzer.get_param('config.apisecret'), "secret")
+        self.assertEqual(self.analyzer.get_param('config.api_secret'), "secret")
 
         # Run the error method
         with self.assertRaises(SystemExit):
@@ -124,6 +126,8 @@ class TestErrorResponse(unittest.TestCase):
         self.assertEqual(json_output['input']['config']['key'], 'REMOVED')
         self.assertEqual(json_output['input']['config']['apikey'], 'REMOVED')
         self.assertEqual(json_output['input']['config']['api_key'], 'REMOVED')
+        self.assertEqual(json_output['input']['config']['apisecret'], 'REMOVED')
+        self.assertEqual(json_output['input']['config']['api_secret'], 'REMOVED')
 
 
 class TestReportResponse(unittest.TestCase):

--- a/tests/test_suite_analyzer.py
+++ b/tests/test_suite_analyzer.py
@@ -109,6 +109,7 @@ class TestErrorResponse(unittest.TestCase):
         self.assertEqual(self.analyzer.get_param('config.api_key'), "secret")
         self.assertEqual(self.analyzer.get_param('config.apisecret'), "secret")
         self.assertEqual(self.analyzer.get_param('config.api_secret'), "secret")
+        self.assertEqual(self.analyzer.get_param('config.secret'), "secret")
 
         # Run the error method
         with self.assertRaises(SystemExit):
@@ -128,6 +129,7 @@ class TestErrorResponse(unittest.TestCase):
         self.assertEqual(json_output['input']['config']['api_key'], 'REMOVED')
         self.assertEqual(json_output['input']['config']['apisecret'], 'REMOVED')
         self.assertEqual(json_output['input']['config']['api_secret'], 'REMOVED')
+        self.assertEqual(json_output['input']['config']['secret'], 'REMOVED')
 
 
 class TestReportResponse(unittest.TestCase):


### PR DESCRIPTION
This PR fixes #10.

I also updated the tests, but haven't run them as they are broken due to #7. 

As a bonus, I also updated the setup url as the current one no longer exists.