### PR TITLE
Read and use CA Cert settings

### DIFF
--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -48,6 +48,11 @@ class Worker(object):
 
         self.__set_proxies()
 
+        # Set CA certificate configuration if available
+        self.cacerts = self.get_param('config.cacerts')
+
+        self.__set_cacerts()
+
         # Finally run check tlp
         if not (self.__check_tlp()):
             self.error('TLP is higher than allowed.')
@@ -60,6 +65,10 @@ class Worker(object):
             os.environ['http_proxy'] = self.http_proxy
         if self.https_proxy is not None:
             os.environ['https_proxy'] = self.https_proxy
+
+    def __set_cacerts(self):
+        if self.cacerts is not None:
+            os.environ['REQUESTS_CA_BUNDLE'] = self.cacerts
 
     @staticmethod
     def __set_encoding():


### PR DESCRIPTION
The current release of cortexutils does not read nor use the setting for CA Certs from the Cortex UI. This PR is meant to solve this issue. It came about trying to use Cortex behind a MITM capable proxy. Sidenote,the UI should indicate that it's the path to the system CA bundle that should be added, not the whole CA Cert in Base64 format