### PR TITLE
Add customizable secret phrase parameter

### DIFF
--- a/cortexutils/analyzer.py
+++ b/cortexutils/analyzer.py
@@ -14,8 +14,8 @@ import ntpath
 
 class Analyzer(Worker):
 
-    def __init__(self, job_directory=None):
-        Worker.__init__(self, job_directory)
+    def __init__(self, job_directory=None, secret_phrases=None):
+        Worker.__init__(self, job_directory, secret_phrases)
 
         # Not breaking compatibility
         self.artifact = self._input

--- a/cortexutils/responder.py
+++ b/cortexutils/responder.py
@@ -8,8 +8,8 @@ from cortexutils.worker import Worker
 
 class Responder(Worker):
 
-    def __init__(self, job_directory=None):
-        Worker.__init__(self, job_directory)
+    def __init__(self, job_directory=None, secret_phrases=None):
+        Worker.__init__(self, job_directory, secret_phrases)
 
         # Not breaking compatibility
         self.artifact = self._input

--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import os
-import sys
 import codecs
 import json
+import os
 import select
+import sys
 
+DEFAULT_SECRET_PHRASES = ("key", "password", "secret")
 
 class Worker(object):
     READ_TIMEOUT = 3  # seconds
 
-    def __init__(self, job_directory):
+    def __init__(self, job_directory, secret_phrases):
         if job_directory is None:
             if len(sys.argv) > 1:
                 job_directory = sys.argv[1]
             else:
                 job_directory = '/job'
         self.job_directory = job_directory
+        if secret_phrases is None:
+            self.secret_phrases = DEFAULT_SECRET_PHRASES
+        else:
+            self.secret_phrases = secret_phrases
         # Load input
         self._input = {}
         if os.path.isfile('%s/input/input.json' % self.job_directory):
@@ -144,13 +149,13 @@ class Worker(object):
         # Get analyzer input
         analyzer_input = self._input
 
-        # Define sensitive key values
-        secrets = ['password', 'key', 'secret']
-
         # Loop over all the sensitive config names and clean them
-        for config_key, v in analyzer_input.get('config', {}).items():
-            if any(secret in config_key.lower() for secret in secrets):
-                analyzer_input.get('config', {})[config_key] = 'REMOVED'
+        for config_key in analyzer_input.get('config', {}).keys():
+            if any(
+                secret_phrase in config_key.lower() 
+                for secret_phrase in self.secret_phrases
+            ):
+                analyzer_input['config'][config_key] = 'REMOVED'
 
         self.__write_output({'success': False,
                              'input': analyzer_input,


### PR DESCRIPTION
Sometimes developers could use a bit more versatility to hide secrets of the input configuration, so I think it made sense to make the secret phrases customizable instead of hardcoding it to the `["password", "secret", "key"]` list.