### PR TITLE
Drop Python 2 support

### DIFF
--- a/cortexutils/analyzer.py
+++ b/cortexutils/analyzer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import tempfile

--- a/cortexutils/analyzer.py
+++ b/cortexutils/analyzer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 import os
 import tempfile
@@ -11,7 +10,7 @@ from cortexutils.worker import Worker
 
 class Analyzer(Worker):
     def __init__(self, job_directory=None, secret_phrases=None):
-        Worker.__init__(self, job_directory, secret_phrases)
+        super().__init__(job_directory, secret_phrases)
 
         # Not breaking compatibility
         self.artifact = self._input
@@ -31,13 +30,13 @@ class Analyzer(Worker):
             return self.get_param("data", None, "Missing data field")
 
     def get_param(self, name, default=None, message=None):
-        data = super(Analyzer, self).get_param(name, default, message)
+        data = super().get_param(name, default, message)
         if (
             name == "file"
             and self.data_type == "file"
             and self.job_directory is not None
         ):
-            path = "%s/input/%s" % (self.job_directory, data)
+            path = f"{self.job_directory}/input/{data}"
             if os.path.isfile(path):
                 return path
         else:
@@ -117,7 +116,7 @@ class Analyzer(Worker):
             operation_list = self.operations(full_report)
         except Exception:
             pass  # nosec B110
-        super(Analyzer, self).report(
+        super().report(
             {
                 "success": True,
                 "summary": summary,

--- a/cortexutils/analyzer.py
+++ b/cortexutils/analyzer.py
@@ -37,9 +37,9 @@ class Analyzer(Worker):
             and self.data_type == "file"
             and self.job_directory is not None
         ):
-            path = f"{self.job_directory}/input/{data}"
-            if os.path.isfile(path):
-                return path
+            input_path = os.path.join(self.job_directory, "input", data)
+            if os.path.isfile(input_path):
+                return input_path
         else:
             return data
 

--- a/cortexutils/extractor.py
+++ b/cortexutils/extractor.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import re
-from builtins import str as unicode
 
 
 class ExtractionError(Exception):
@@ -67,7 +66,7 @@ class Extractor:
             + "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
             + ")"
         )
-        regex.append({"type": "ip", "regex": re.compile(r"{}".format(r))})
+        regex.append({"type": "ip", "regex": re.compile(r)})
 
         # URL
         regex.append({"type": "url", "regex": re.compile(r"^(http://|https://)")})
@@ -95,7 +94,7 @@ class Extractor:
             {
                 "type": "user-agent",
                 "regex": re.compile(
-                    r"^(Mozilla/[45]\.0 |AppleWebKit/[0-9]{3}\.[0-9]{2} |Chrome/[0-9]{2}\.[0-9]\."  # noqa
+                    r"^(Mozilla/[45]\.0 |AppleWebKit/[0-9]{3}\.[0-9]{2} |Chrome/[0-9]{2}\.[0-9]\."  # noqa: E501
                     r"[0-9]{4}\.[0-9]{3} |Safari/[0-9]{3}\.[0-9]{2} ).*?$"
                 ),
             }
@@ -115,7 +114,7 @@ class Extractor:
                 "type": "registry",
                 "regex": re.compile(
                     r"^(HKEY|HKLM|HKCU|HKCR|HKCC)"
-                    r"(_LOCAL_MACHINE|_CURRENT_USER|_CURRENT_CONFIG|_CLASSES_ROOT|)[\\a-zA-Z0-9]+$"  # noqa
+                    r"(_LOCAL_MACHINE|_CURRENT_USER|_CURRENT_CONFIG|_CLASSES_ROOT|)[\\a-zA-Z0-9]+$"  # noqa: E501
                 ),
             }
         )
@@ -149,7 +148,7 @@ class Extractor:
             if self.ignore == value:
                 return ""
 
-        if isinstance(value, (str, unicode)):
+        if isinstance(value, str):
             for r in self.regex:
                 if r.get("regex").match(value):
                     return r.get("type")
@@ -179,7 +178,7 @@ class Extractor:
         """
         results = []
         # Only the string left
-        if isinstance(iterable, (str, unicode)):
+        if isinstance(iterable, str):
             dt = self.__checktype(iterable)
             if len(dt) > 0:
                 results.append({"dataType": dt, "data": iterable})

--- a/cortexutils/extractor.py
+++ b/cortexutils/extractor.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import re
 
 

--- a/cortexutils/responder.py
+++ b/cortexutils/responder.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
-# encoding: utf-8
-
 from cortexutils.worker import Worker
 
 
 class Responder(Worker):
     def __init__(self, job_directory=None, secret_phrases=None):
-        Worker.__init__(self, job_directory, secret_phrases)
+        super().__init__(job_directory, secret_phrases)
 
         # Not breaking compatibility
         self.artifact = self._input
@@ -28,7 +26,7 @@ class Responder(Worker):
             operation_list = self.operations(full_report)
         except Exception:
             pass  # nosec B110
-        super(Responder, self).report(
+        super().report(
             {"success": True, "full": full_report, "operations": operation_list},
             ensure_ascii,
         )

--- a/cortexutils/responder.py
+++ b/cortexutils/responder.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from cortexutils.worker import Worker
 
 

--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
-
 import codecs
 import json
 import os
@@ -9,7 +7,7 @@ import sys
 DEFAULT_SECRET_PHRASES = ("key", "password", "secret")
 
 
-class Worker(object):
+class Worker:
     READ_TIMEOUT = 3  # seconds
 
     def __init__(self, job_directory, secret_phrases):
@@ -25,8 +23,9 @@ class Worker(object):
             self.secret_phrases = secret_phrases
         # Load input
         self._input = {}
-        if os.path.isfile("%s/input/input.json" % self.job_directory):
-            with open("%s/input/input.json" % self.job_directory) as f_input:
+        input_path = f"{self.job_directory}/input/input.json"
+        if os.path.isfile(input_path):
+            with open(input_path) as f_input:
                 self._input = json.load(f_input)
         else:
             # If input file doesn't exist,
@@ -72,15 +71,9 @@ class Worker(object):
     def __set_encoding():
         try:
             if sys.stdout.encoding != "UTF-8":
-                if sys.version_info[0] == 3:
-                    sys.stdout = codecs.getwriter("utf-8")(sys.stdout.buffer, "strict")
-                else:
-                    sys.stdout = codecs.getwriter("utf-8")(sys.stdout, "strict")
+                sys.stdout = codecs.getwriter("utf-8")(sys.stdout.buffer, "strict")
             if sys.stderr.encoding != "UTF-8":
-                if sys.version_info[0] == 3:
-                    sys.stderr = codecs.getwriter("utf-8")(sys.stderr.buffer, "strict")
-                else:
-                    sys.stderr = codecs.getwriter("utf-8")(sys.stderr, "strict")
+                sys.stderr = codecs.getwriter("utf-8")(sys.stderr.buffer, "strict")
         except Exception:
             pass  # nosec B110
 
@@ -123,13 +116,9 @@ class Worker(object):
         if self.job_directory is None:
             json.dump(data, sys.stdout, ensure_ascii=ensure_ascii)
         else:
-            try:
-                os.makedirs("%s/output" % self.job_directory)
-            except Exception:
-                pass  # nosec B110
-            with open(
-                "%s/output/output.json" % self.job_directory, mode="w"
-            ) as f_output:
+            output_path = f"{self.job_directory}/output"
+            os.makedirs(output_path, exist_ok=True)
+            with open(f"{output_path}/output.json", mode="w") as f_output:
                 json.dump(data, f_output, ensure_ascii=ensure_ascii)
 
     def get_data(self):

--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import codecs
 import json
 import os

--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -17,7 +17,7 @@ class Worker:
             if len(sys.argv) > 1:
                 job_directory = sys.argv[1]
             else:
-                job_directory = "/job"
+                job_directory = os.path.join(job_directory, "job")
         self.job_directory = job_directory
         if secret_phrases is None:
             self.secret_phrases = DEFAULT_SECRET_PHRASES
@@ -25,7 +25,7 @@ class Worker:
             self.secret_phrases = secret_phrases
         # Load input
         self._input = {}
-        input_path = f"{self.job_directory}/input/input.json"
+        input_path = os.path.join(self.job_directory, "input", "input.json")
         if os.path.isfile(input_path):
             with open(input_path) as f_input:
                 self._input = json.load(f_input)
@@ -118,9 +118,10 @@ class Worker:
         if self.job_directory is None:
             json.dump(data, sys.stdout, ensure_ascii=ensure_ascii)
         else:
-            output_path = f"{self.job_directory}/output"
-            os.makedirs(output_path, exist_ok=True)
-            with open(f"{output_path}/output.json", mode="w") as f_output:
+            output_dir = os.path.join(self.job_directory, "output")
+            os.makedirs(output_dir, exist_ok=True)
+            output_path = os.path.join(output_dir, "output.json")
+            with open(output_path, mode="w") as f_output:
                 json.dump(data, f_output, ensure_ascii=ensure_ascii)
 
     def get_data(self):

--- a/cortexutils/worker.py
+++ b/cortexutils/worker.py
@@ -17,7 +17,7 @@ class Worker:
             if len(sys.argv) > 1:
                 job_directory = sys.argv[1]
             else:
-                job_directory = os.path.join(job_directory, "job")
+                job_directory = "/job"
         self.job_directory = job_directory
         if secret_phrases is None:
             self.secret_phrases = DEFAULT_SECRET_PHRASES

--- a/tests/test_suite_analyzer.py
+++ b/tests/test_suite_analyzer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import sys

--- a/tests/test_suite_analyzer.py
+++ b/tests/test_suite_analyzer.py
@@ -1,26 +1,19 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import os
 import sys
 import json
 import unittest
 
-from io import open
 from cortexutils.analyzer import Analyzer
 
-# Different lib when using python3 or 2
-if sys.version_info >= (3, 0):
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 
 def load_test_fixture(fixture_path):
     path = os.path.dirname(os.path.abspath(__file__))
-    fixture_file = open(path + "/" + fixture_path)
-    input = fixture_file.read()
-    fixture_file.close()
+    with open(path + "/" + fixture_path) as fixture_file:
+        input = fixture_file.read()
     sys.stdin = StringIO(input)
     sys.stdout = StringIO()
 

--- a/tests/test_suite_analyzer.py
+++ b/tests/test_suite_analyzer.py
@@ -12,8 +12,9 @@ from io import StringIO
 
 
 def load_test_fixture(fixture_path):
-    path = os.path.dirname(os.path.abspath(__file__))
-    with open(path + "/" + fixture_path) as fixture_file:
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(tests_dir, fixture_path)
+    with open(file_path) as fixture_file:
         input = fixture_file.read()
     sys.stdin = StringIO(input)
     sys.stdout = StringIO()
@@ -21,7 +22,8 @@ def load_test_fixture(fixture_path):
 
 class TestMinimalConfig(unittest.TestCase):
     def setUp(self):
-        load_test_fixture("fixtures/test-minimal-config.json")
+        fixture_path = os.path.join("fixtures", "test-minimal-config.json")
+        load_test_fixture(fixture_path)
         self.analyzer = Analyzer()
 
     def test_default_config(self):
@@ -43,7 +45,8 @@ class TestMinimalConfig(unittest.TestCase):
 
 class TestProxyConfig(unittest.TestCase):
     def setUp(self):
-        load_test_fixture("fixtures/test-proxy-config.json")
+        fixture_path = os.path.join("fixtures", "test-proxy-config.json")
+        load_test_fixture(fixture_path)
         self.analyzer = Analyzer()
 
     def test_proxy_config(self):
@@ -58,7 +61,8 @@ class TestProxyConfig(unittest.TestCase):
 
 class TestTlpConfig(unittest.TestCase):
     def setUp(self):
-        load_test_fixture("fixtures/test-tlp-config.json")
+        fixture_path = os.path.join("fixtures", "test-tlp-config.json")
+        load_test_fixture(fixture_path)
         self.analyzer = Analyzer()
 
     def test_check_tlp_disabled(self):
@@ -89,7 +93,8 @@ class TestTlpConfig(unittest.TestCase):
 
 class TestErrorResponse(unittest.TestCase):
     def setUp(self):
-        load_test_fixture("fixtures/test-error-response.json")
+        fixture_path = os.path.join("fixtures", "test-error-response.json")
+        load_test_fixture(fixture_path)
         self.analyzer = Analyzer()
 
     def test_error_response(self):
@@ -124,7 +129,8 @@ class TestErrorResponse(unittest.TestCase):
 
 class TestReportResponse(unittest.TestCase):
     def setUp(self):
-        load_test_fixture("fixtures/test-report-response.json")
+        fixture_path = os.path.join("fixtures", "test-report-response.json")
+        load_test_fixture(fixture_path)
         self.analyzer = Analyzer()
 
     def test_report_response(self):

--- a/tests/test_suite_extractor.py
+++ b/tests/test_suite_extractor.py
@@ -23,13 +23,6 @@ class TestExtractorValidInput(unittest.TestCase):
             "FQDN single string: wrong data type.",
         )
 
-    def test_single_fqdn_as_unicode(self):
-        self.assertEqual(
-            self.extractor.check_string(value="www.m\u00fcnchen.de"),
-            "fqdn",
-            "FQDN single string: wrong data type.",
-        )
-
     def test_single_domain(self):
         self.assertEqual(
             self.extractor.check_string(value="google.de"),

--- a/tests/test_suite_extractor.py
+++ b/tests/test_suite_extractor.py
@@ -25,7 +25,7 @@ class TestExtractorValidInput(unittest.TestCase):
 
     def test_single_fqdn_as_unicode(self):
         self.assertEqual(
-            self.extractor.check_string(value="www.google.de"),
+            self.extractor.check_string(value="www.m\u00fcnchen.de"),
             "fqdn",
             "FQDN single string: wrong data type.",
         )

--- a/tests/test_suite_extractor.py
+++ b/tests/test_suite_extractor.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """
 This contains the unit tests for the extractor.
 """

--- a/tests/test_suite_integration.py
+++ b/tests/test_suite_integration.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
-# coding: utf-8
 import json
 import unittest
 import sys
 
 from cortexutils.analyzer import Analyzer
 
-# Different lib when using python3 or 2
-if sys.version_info >= (3, 0):
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 
 class AnalyzerExtractorOutputTest(unittest.TestCase):

--- a/tests/test_suite_integration.py
+++ b/tests/test_suite_integration.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import json
 import unittest
 import sys


### PR DESCRIPTION
* Encoding special comment line is still required if there is a shebang as per https://docs.python.org/3/tutorial/interpreter.html#source-code-encoding.
* Changed special comment line (encoding) to `# -*- coding: utf-8 -*-` form
* Super does not require class name https://peps.python.org/pep-3135/
* Modernize % format strings to f-strings
* Drop `from builtins import str as unicode` (all text should be unicode https://docs.python.org/3/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit)
* Use `with` statement instead of raw `open`
* Drop all `sys.version_info` checks and branches
* Remove inherit from object (actually this is a prerequisite if we want to make the Worker ABC later)

https://docs.python.org/3/whatsnew/3.0.html